### PR TITLE
Update Equivalence_reasoning.md

### DIFF
--- a/doc/en/Authoring/Equivalence_reasoning.md
+++ b/doc/en/Authoring/Equivalence_reasoning.md
@@ -62,6 +62,8 @@ We need to tell STACK to compare the first line of the student's working to the 
 Type `firstline` into the Extra options box within the `Input:ans1` header.
 This ensures a student's response will be invalid if they don't have the correct first line.
 
+`firstline` can also be used in the Syntax hit box. The first line is then already written in the answer-field when the student opens the question.
+
 ### Setting the potential response tree ###
 
 As a minimal potential response tree have one node, with 


### PR DESCRIPTION
I added:

`firstline` can also be used in the Syntax hit box. The first line is then already written in the answer-field when the student opens the question.

to the docs addressing #798 